### PR TITLE
refactor: reworked variables

### DIFF
--- a/core/eval/eval_test.go
+++ b/core/eval/eval_test.go
@@ -63,7 +63,7 @@ func TestEvalVariables(t *testing.T) {
 	}{
 		{
 			str: "(: a 6)",
-			exp: "[6]",
+			exp: "6",
 		},
 		{
 			str: "(: b 1 2 3)",
@@ -71,19 +71,19 @@ func TestEvalVariables(t *testing.T) {
 		},
 		{
 			str: "(: c (* 5 5))",
-			exp: "[25]",
+			exp: "25",
 		},
 		{
 			str: "(: d (: e (+ 5 5)))",
-			exp: "[[10]]",
+			exp: "10",
 		},
 		{
 			str: "(: f true)",
-			exp: "[true]",
+			exp: "true",
 		},
 		{
 			str: "(: g false)",
-			exp: "[false]",
+			exp: "false",
 		},
 	}
 	for _, i := range input {
@@ -188,8 +188,8 @@ func TestEvalFunction(t *testing.T) {
 			exp: "<nil>",
 		},
 		{
-			str: `($ concat (_ a) (, a))(: y "a" "b" "c" "d")(concat y)`,
-			exp: "abcd",
+			str: `($ concat (_ a b c) (, a b c))(: y "a")(concat y y y)`,
+			exp: "aaa",
 		},
 	}
 	for _, i := range input {

--- a/core/expr/add.go
+++ b/core/expr/add.go
@@ -15,9 +15,13 @@ func (a *Add) Eval() any {
 	if len(a.Children) == 0 {
 		return 0.0
 	}
-	res := extractChild(a.Children[0], token.ADD)
-	for _, c := range a.Children[1:] {
-		res += extractChild(c, token.ADD)
+	res := 0.0
+	for i, c := range a.Children {
+		if i == 0 {
+			res = castPanicIfNotType[float64](c.Eval(), token.ADD)
+		} else {
+			res += castPanicIfNotType[float64](c.Eval(), token.ADD)
+		}
 	}
 	return res
 }

--- a/core/expr/and.go
+++ b/core/expr/and.go
@@ -12,18 +12,8 @@ func (a *And) GetToken() token.Token {
 }
 
 func (a *And) Eval() any {
-	list := make([]bool, 0)
 	for _, c := range a.Children {
-		ev := c.Eval()
-		if val, ok := isType[[]interface{}](ev); ok {
-			for _, v := range val {
-				list = append(list, castPanicIfNotType[bool](v, token.AND))
-			}
-		} else {
-			list = append(list, castPanicIfNotType[bool](ev, token.AND))
-		}
-	}
-	for _, v := range list {
+		v := castPanicIfNotType[bool](c.Eval(), token.AND)
 		if !v {
 			return false
 		}

--- a/core/expr/concat.go
+++ b/core/expr/concat.go
@@ -17,14 +17,7 @@ func (c *Concat) GetToken() token.Token {
 func (c *Concat) Eval() any {
 	b := strings.Builder{}
 	for _, c := range c.Children {
-		ev := c.Eval()
-		if val, ok := isType[[]interface{}](ev); ok {
-			for _, s := range val {
-				b.WriteString(castPanicIfNotType[string](s, token.CONCAT))
-			}
-		} else {
-			b.WriteString(castPanicIfNotType[string](ev, token.CONCAT))
-		}
+		b.WriteString(castPanicIfNotType[string](c.Eval(), token.CONCAT))
 	}
 	return b.String()
 }

--- a/core/expr/div.go
+++ b/core/expr/div.go
@@ -15,9 +15,13 @@ func (d *Div) Eval() any {
 	if len(d.Children) == 0 {
 		return 0.0
 	}
-	res := extractChild(d.Children[0], token.DIV)
-	for _, c := range d.Children[1:] {
-		res /= extractChild(c, token.DIV)
+	res := 0.0
+	for i, c := range d.Children {
+		if i == 0 {
+			res = castPanicIfNotType[float64](c.Eval(), token.DIV)
+		} else {
+			res /= castPanicIfNotType[float64](c.Eval(), token.DIV)
+		}
 	}
 	return res
 }

--- a/core/expr/equal.go
+++ b/core/expr/equal.go
@@ -12,20 +12,11 @@ func (e *Equal) GetToken() token.Token {
 }
 
 func (e *Equal) Eval() any {
-	list := make([]any, 0)
-	for _, c := range e.Children {
-		ev := c.Eval()
-		if val, ok := isType[[]interface{}](ev); ok {
-			list = append(list, val...)
-		} else {
-			list = append(list, ev)
-		}
-	}
-	for i := range list {
-		if i > 0 {
-			if list[i-1] != list[i] {
-				return false
-			}
+	list := make([]any, len(e.Children))
+	for i, c := range e.Children {
+		list[i] = c.Eval()
+		if i >= 1 && list[i-1] != list[i] {
+			return false
 		}
 	}
 	return true

--- a/core/expr/mod.go
+++ b/core/expr/mod.go
@@ -16,9 +16,13 @@ func (m *Mod) Eval() any {
 		return 0.0
 	}
 
-	res := extractChild(m.Children[0], token.MOD)
-	for _, c := range m.Children[1:] {
-		res = float64(int(res) % int(extractChild(c, token.MOD)))
+	res := 0
+	for i, c := range m.Children {
+		if i == 0 {
+			res = int(castPanicIfNotType[float64](c.Eval(), token.MOD))
+		} else {
+			res = res % int(castPanicIfNotType[float64](c.Eval(), token.MOD))
+		}
 	}
 	return res
 }

--- a/core/expr/mul.go
+++ b/core/expr/mul.go
@@ -15,9 +15,13 @@ func (m *Mul) Eval() any {
 	if len(m.Children) == 0 {
 		return 0.0
 	}
-	res := extractChild(m.Children[0], token.MUL)
-	for _, c := range m.Children[1:] {
-		res *= extractChild(c, token.MUL)
+	res := 0.0
+	for i, c := range m.Children {
+		if i == 0 {
+			res = castPanicIfNotType[float64](c.Eval(), token.MUL)
+		} else {
+			res *= castPanicIfNotType[float64](c.Eval(), token.MUL)
+		}
 	}
 	return res
 }

--- a/core/expr/or.go
+++ b/core/expr/or.go
@@ -12,19 +12,8 @@ func (o *Or) GetToken() token.Token {
 }
 
 func (o *Or) Eval() any {
-	list := make([]bool, 0)
 	for _, c := range o.Children {
-		ev := c.Eval()
-		if val, ok := isType[[]interface{}](ev); ok {
-			for _, v := range val {
-				list = append(list, castPanicIfNotType[bool](v, token.OR))
-			}
-		} else {
-			list = append(list, castPanicIfNotType[bool](ev, token.OR))
-		}
-	}
-	for _, v := range list {
-		if v {
+		if castPanicIfNotType[bool](c.Eval(), token.OR) {
 			return true
 		}
 	}

--- a/core/expr/sub.go
+++ b/core/expr/sub.go
@@ -15,9 +15,13 @@ func (s *Sub) Eval() any {
 	if len(s.Children) == 0 {
 		return 0.0
 	}
-	res := extractChild(s.Children[0], token.SUB)
-	for _, c := range s.Children[1:] {
-		res -= extractChild(c, token.SUB)
+	res := 0.0
+	for i, c := range s.Children {
+		if i == 0 {
+			res = castPanicIfNotType[float64](c.Eval(), token.SUB)
+		} else {
+			res -= castPanicIfNotType[float64](c.Eval(), token.SUB)
+		}
 	}
 	return res
 }

--- a/core/expr/util.go
+++ b/core/expr/util.go
@@ -8,52 +8,9 @@ import (
 // attempts to cast `in` to `T`, returns `in` cast to `T` if successful. If
 // cast fails, panics.
 func castPanicIfNotType[T any](in any, op int) T {
-	val, ok := isType[T](in)
-	if !ok {
-		panic(fmt.Sprintf("can not use variable of type %T in current operation (%s), expected %T for value %+v", in, token.TOKEN_NAME_MAP[op], val, in))
-	}
-	return val
-}
-
-// checks if `in` is castable to `T`, returns casted value and true if
-// castable, zero value of `T` and false if not
-func isType[T any](in any) (T, bool) {
 	val, ok := in.(T)
 	if !ok {
-		var e T
-		return e, false
-	}
-	return val, true
-}
-
-func extractChild(n Node, op int) float64 {
-	var val float64
-	if idt, ok := isType[*Ident](n); ok {
-		arr, ok := isType[[]interface{}](idt.Eval())
-		if !ok {
-			val = castPanicIfNotType[float64](n.Eval(), op)
-		}
-		for i, item := range arr {
-			t := castPanicIfNotType[float64](item, op)
-			if i == 0 {
-				val = t
-				continue
-			}
-			switch op {
-			case token.ADD:
-				val += t
-			case token.SUB:
-				val -= t
-			case token.DIV:
-				val /= t
-			case token.MUL:
-				val *= t
-			case token.MOD:
-				val = float64(int(val) % int(t))
-			}
-		}
-	} else {
-		val = castPanicIfNotType[float64](n.Eval(), op)
+		panic(fmt.Sprintf("can not use variable of type %T in current operation (%s), expected %T for value %+v", in, token.TOKEN_NAME_MAP[op], val, in))
 	}
 	return val
 }

--- a/core/expr/var.go
+++ b/core/expr/var.go
@@ -17,9 +17,14 @@ func (v *Var) GetToken() token.Token {
 }
 
 func (v *Var) Eval() any {
-	val := make([]any, len(v.Value))
-	for i, c := range v.Value {
-		val[i] = c.Eval()
+	var val any
+	if len(v.Value) > 1 {
+		val = make([]any, len(v.Value))
+		for i, c := range v.Value {
+			val.([]any)[i] = c.Eval()
+		}
+	} else {
+		val = v.Value[0].Eval()
 	}
 
 	consts.SYMBOL_TABLE[v.Name] = val


### PR DESCRIPTION
Before variables declared via the ':'-operator were all arrays, which is bad design because i shot myself in the foot while trying to implement and, or and arithmetic operations. Now variables defined with one child, such as the following are no longer arrays, which was the default behaviour before.

    (: a 1)     ;; <- a just contains 1
    (: b 1 2 3) ;; <- b contains an array with 1,2 and 3

Due to this change i could slim down the following expressions significantly:

- add           (+)
- sub           (-)
- div           (/)
- mul           (*)
- mod           (%)
- and           (&)
- or            (|)
- equals        (=)

Which does however mean the above do no longer accept variables that are arrays. In the future a function to accumulate values of an array and one to iterate over an array are planned.

The change did also allow me to inline 'expr.isType' into its now only usage in 'expr.castPanicIfNotType'.

Changelist:
- removed arrays support for most operators
- updated tests to match the above changes
- moved from all variables are arrays to declare variable with just one argument -> normal variable, declare variable with multiple arguments -> array

```
The following changes since commit be1f6ebafbedff51f3222b06460bee42ca9cfba1:

  feat(repl): repl commands for debugging (2023-08-11 08:03:55 +0200)

are available in the Git repository at:

  https://github.com/xnacly/sophia

for you to fetch changes up to dcd2810b558b0cfbd85527ec93af255b483e4a83:

  refactor: reworked variables (2023-08-11 08:32:36 +0200)

----------------------------------------------------------------
xnacly (1):
      refactor: reworked variables

 core/eval/eval_test.go | 14 +++++++-------
 core/expr/add.go       | 10 +++++++---
 core/expr/and.go       | 12 +-----------
 core/expr/concat.go    |  9 +--------
 core/expr/div.go       | 10 +++++++---
 core/expr/equal.go     | 19 +++++--------------
 core/expr/mod.go       | 10 +++++++---
 core/expr/mul.go       | 10 +++++++---
 core/expr/or.go        | 13 +------------
 core/expr/sub.go       | 10 +++++++---
 core/expr/util.go      | 45 +--------------------------------------------
 core/expr/var.go       | 11 ++++++++---
 12 files changed, 59 insertions(+), 114 deletions(-)
```