### PR TITLE
sophia/parser: object attached functions:

### DIFF
--- a/core/expr/func.go
+++ b/core/expr/func.go
@@ -25,12 +25,14 @@ func (f *Func) Eval() any {
 		return nil
 	} else if f.Name.GetToken().Type == token.LEFT_BRACKET {
 		i, _ := f.Name.(*Index)
-		ident := castPanicIfNotType[*Ident](i.Element, token.LEFT_BRACKET)
-		index := castPanicIfNotType[*Ident](i.Index, token.LEFT_BRACKET)
-		_, found := consts.SYMBOL_TABLE[ident.Name]
+		ident := castPanicIfNotType[*Ident](i.Element, token.FUNC)
+		index := castPanicIfNotType[*Ident](i.Index, token.FUNC)
+		requested, found := consts.SYMBOL_TABLE[ident.Name]
 		if !found {
 			panic(fmt.Sprintf("can't define function %q on not existing object %q", index.Name, ident.Name))
 		}
+		requestedObject := castPanicIfNotType[map[string]interface{}](requested, token.FUNC)
+		requestedObject[index.Name] = f
 	}
 	return nil
 }

--- a/core/expr/func.go
+++ b/core/expr/func.go
@@ -1,6 +1,7 @@
 package expr
 
 import (
+	"fmt"
 	"sophia/core/consts"
 	"sophia/core/token"
 	"strings"
@@ -19,7 +20,18 @@ func (f *Func) GetToken() token.Token {
 }
 
 func (f *Func) Eval() any {
-	consts.FUNC_TABLE[f.Name.GetToken().Raw] = f
+	if f.Name.GetToken().Type == token.IDENT {
+		consts.FUNC_TABLE[f.Name.GetToken().Raw] = f
+		return nil
+	} else if f.Name.GetToken().Type == token.LEFT_BRACKET {
+		i, _ := f.Name.(*Index)
+		ident := castPanicIfNotType[*Ident](i.Element, token.LEFT_BRACKET)
+		index := castPanicIfNotType[*Ident](i.Index, token.LEFT_BRACKET)
+		_, found := consts.SYMBOL_TABLE[ident.Name]
+		if !found {
+			panic(fmt.Sprintf("can't define function %q on not existing object %q", index.Name, ident.Name))
+		}
+	}
 	return nil
 }
 

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -202,8 +202,8 @@ func (p *Parser) parseStatment() expr.Node {
 			p.HasError = true
 			return nil
 		}
-		if childs[0].GetToken().Type != token.IDENT {
-			log.Printf("err: expected the first argument for function definition to be of type IDENT, got %q", token.TOKEN_NAME_MAP[childs[0].GetToken().Type])
+		if childs[0].GetToken().Type != token.IDENT && childs[0].GetToken().Type != token.LEFT_BRACKET {
+			log.Printf("err: expected the first argument for function definition to be of type IDENT or of type LEFT_BRACKET, got %q", token.TOKEN_NAME_MAP[childs[0].GetToken().Type])
 			p.HasError = true
 			return nil
 		}

--- a/examples/objects.phia
+++ b/examples/objects.phia
@@ -1,0 +1,4 @@
+(let person {})
+(fun [person.String] (_) (put "test"))
+;; not yet implemented
+;;([person.String])


### PR DESCRIPTION
This pr lays the ground work for attaching functions to objects using the following notation:

```lisp
(let person {})
(fun Printer (_ value) (put value))
([person.Printer] "Hello World")
```

A shorthand for calling these function is planned as:
```lisp
(person::Printer "Hello World")
```

- [x] rework parsing function definition
- [x] attach functions to object in `consts.SYMBOL_TABLE` internally
- [ ] rework function calls to accept the index notation (could be done by moving the check for a valid function from `parser.parseStatement` to `expr.Call`)