### PR TITLE
core/serror: ErrorFormatter structure for advanced error display

### DIFF
--- a/core/conf.go
+++ b/core/conf.go
@@ -1,13 +1,15 @@
 package core
 
 const ASCII_ART = `
-  +####
- +\    #
-+  \ ß  #
-+   \   # <-> ß-calculus
-+ ß  \  #
- +    \#
-  ++++#
+  ██████  ▒█████   ██▓███   ██░ ██  ██▓ ▄▄▄      
+▒██    ▒ ▒██▒  ██▒▓██░  ██▒▓██░ ██▒▓██▒▒████▄    
+░ ▓██▄   ▒██░  ██▒▓██░ ██▓▒▒██▀▀██░▒██▒▒██  ▀█▄  
+  ▒   ██▒▒██   ██░▒██▄█▓▒ ▒░▓█ ░██ ░██░░██▄▄▄▄██ 
+▒██████▒▒░ ████▓▒░▒██▒ ░  ░░▓█▒░██▓░██░ ▓█   ▓██▒
+▒ ▒▓▒ ▒ ░░ ▒░▒░▒░ ▒▓▒░ ░  ░ ▒ ░░▒░▒░▓   ▒▒   ▓▒█░
+░ ░▒  ░ ░  ░ ▒ ▒░ ░▒ ░      ▒ ░▒░ ░ ▒ ░  ▒   ▒▒ ░
+░  ░  ░  ░ ░ ░ ▒  ░░        ░  ░░ ░ ▒ ░  ░   ▒   
+      ░      ░ ░            ░  ░  ░ ░        ░  ░
 `
 
 // available targets to compile sophia to
@@ -19,8 +21,9 @@ var TARGETS = map[string]struct{}{
 }
 
 type Config struct {
-	Debug  bool   // enable debug logs
-	Target string // target to compile sophia to
+	Debug     bool // enable debug logs
+	AllErrors bool
+	Target    string // target to compile sophia to
 }
 
 var CONF = Config{

--- a/core/eval/eval_test.go
+++ b/core/eval/eval_test.go
@@ -5,7 +5,6 @@ import (
 	"sophia/core/lexer"
 	"sophia/core/parser"
 	"sophia/core/serror"
-	"strings"
 	"testing"
 )
 
@@ -41,17 +40,12 @@ func TestEvalAritmetic(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i.str, func(t *testing.T) {
-			errorFmt := serror.ErrorFormatter{
-				Conf:    &core.CONF,
-				Lines:   strings.Split(string(i.str), "\n"),
-				Errors:  make([]serror.Error, 0),
-				Builder: &strings.Builder{},
-			}
-			l := lexer.New([]byte(i.str), &errorFmt)
-			p := parser.New(l.Lex(), "test", &errorFmt)
+			serror.SetDefault(serror.NewFormatter(&core.CONF, i.str, "test"))
+			l := lexer.New(i.str)
+			p := parser.New(l.Lex(), "test")
 			r := Eval(p.Parse())
 
-			if p.ErrorFormatter.HasErrors() {
+			if serror.HasErrors() {
 				t.Errorf("lexer or parser error for %q", i.str)
 			}
 			if len(r) == 0 {
@@ -97,16 +91,11 @@ func TestEvalVariables(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i.str, func(t *testing.T) {
-			errorFmt := serror.ErrorFormatter{
-				Conf:    &core.CONF,
-				Lines:   strings.Split(string(i.str), "\n"),
-				Errors:  make([]serror.Error, 0),
-				Builder: &strings.Builder{},
-			}
-			l := lexer.New([]byte(i.str), &errorFmt)
-			p := parser.New(l.Lex(), "test", &errorFmt)
+			serror.SetDefault(serror.NewFormatter(&core.CONF, i.str, "test"))
+			l := lexer.New(i.str)
+			p := parser.New(l.Lex(), "test")
 			r := Eval(p.Parse())
-			if p.ErrorFormatter.HasErrors() {
+			if serror.HasErrors() {
 				t.Errorf("lexer or parser error for %q", i.str)
 			}
 			if len(r) == 0 {
@@ -191,16 +180,11 @@ func TestEvalConditional(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i.str, func(t *testing.T) {
-			errorFmt := serror.ErrorFormatter{
-				Conf:    &core.CONF,
-				Lines:   strings.Split(string(i.str), "\n"),
-				Errors:  make([]serror.Error, 0),
-				Builder: &strings.Builder{},
-			}
-			l := lexer.New([]byte(i.str), &errorFmt)
-			p := parser.New(l.Lex(), "test", &errorFmt)
+			serror.SetDefault(serror.NewFormatter(&core.CONF, i.str, "test"))
+			l := lexer.New(i.str)
+			p := parser.New(l.Lex(), "test")
 			r := Eval(p.Parse())
-			if p.ErrorFormatter.HasErrors() {
+			if serror.HasErrors() {
 				t.Errorf("lexer or parser error for %q", i.str)
 			}
 			if len(r) == 0 {
@@ -233,25 +217,18 @@ func TestEvalArraySpread(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i.str, func(t *testing.T) {
-			errorFmt := serror.ErrorFormatter{
-				Conf:    &core.CONF,
-				Lines:   strings.Split(string(i.str), "\n"),
-				Errors:  make([]serror.Error, 0),
-				Builder: &strings.Builder{},
-			}
-			l := lexer.New([]byte(i.str), &errorFmt)
-			p := parser.New(l.Lex(), "test", &errorFmt)
+			serror.SetDefault(serror.NewFormatter(&core.CONF, i.str, "test"))
+			l := lexer.New(i.str)
+			p := parser.New(l.Lex(), "test")
 			r := Eval(p.Parse())
-			if p.ErrorFormatter.HasErrors() {
+			if serror.HasErrors() {
 				t.Errorf("lexer or parser error for %q", i.str)
 			}
 			if len(r) == 0 {
-				t.Errorf("eval result empty for %q", i.str)
-				return
+				t.Errorf("eval result empty")
 			}
-			got := r[len(r)-1]
-			if i.exp != got {
-				t.Errorf("got %q, wanted %q", got, i.exp)
+			if i.exp != r[0] {
+				t.Errorf("%q not equal to %q", i.exp, r[0])
 			}
 		})
 	}
@@ -281,16 +258,11 @@ func TestEvalMerge(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i.str, func(t *testing.T) {
-			errorFmt := serror.ErrorFormatter{
-				Conf:    &core.CONF,
-				Lines:   strings.Split(string(i.str), "\n"),
-				Errors:  make([]serror.Error, 0),
-				Builder: &strings.Builder{},
-			}
-			l := lexer.New([]byte(i.str), &errorFmt)
-			p := parser.New(l.Lex(), "test", &errorFmt)
+			serror.SetDefault(serror.NewFormatter(&core.CONF, i.str, "test"))
+			l := lexer.New(i.str)
+			p := parser.New(l.Lex(), "test")
 			r := Eval(p.Parse())
-			if p.ErrorFormatter.HasErrors() {
+			if serror.HasErrors() {
 				t.Errorf("lexer or parser error for %q", i.str)
 			}
 			if len(r) == 0 {
@@ -325,16 +297,11 @@ func TestEvalFunction(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i.str, func(t *testing.T) {
-			errorFmt := serror.ErrorFormatter{
-				Conf:    &core.CONF,
-				Lines:   strings.Split(string(i.str), "\n"),
-				Errors:  make([]serror.Error, 0),
-				Builder: &strings.Builder{},
-			}
-			l := lexer.New([]byte(i.str), &errorFmt)
-			p := parser.New(l.Lex(), "test", &errorFmt)
+			serror.SetDefault(serror.NewFormatter(&core.CONF, i.str, "test"))
+			l := lexer.New(i.str)
+			p := parser.New(l.Lex(), "test")
 			r := Eval(p.Parse())
-			if p.ErrorFormatter.HasErrors() {
+			if serror.HasErrors() {
 				t.Errorf("lexer or parser error for %q", i.str)
 			}
 			if len(r) == 0 {
@@ -362,16 +329,11 @@ func TestEvalLoop(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i.str, func(t *testing.T) {
-			errorFmt := serror.ErrorFormatter{
-				Conf:    &core.CONF,
-				Lines:   strings.Split(string(i.str), "\n"),
-				Errors:  make([]serror.Error, 0),
-				Builder: &strings.Builder{},
-			}
-			l := lexer.New([]byte(i.str), &errorFmt)
-			p := parser.New(l.Lex(), "test", &errorFmt)
+			serror.SetDefault(serror.NewFormatter(&core.CONF, i.str, "test"))
+			l := lexer.New(i.str)
+			p := parser.New(l.Lex(), "test")
 			r := Eval(p.Parse())
-			if p.ErrorFormatter.HasErrors() {
+			if serror.HasErrors() {
 				t.Errorf("lexer or parser error for %q", i.str)
 			}
 			if len(r) == 0 {

--- a/core/eval/eval_test.go
+++ b/core/eval/eval_test.go
@@ -1,8 +1,11 @@
 package eval
 
 import (
+	"sophia/core"
 	"sophia/core/lexer"
 	"sophia/core/parser"
+	"sophia/core/serror"
+	"strings"
 	"testing"
 )
 
@@ -38,12 +41,18 @@ func TestEvalAritmetic(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i.str, func(t *testing.T) {
-			l := lexer.New([]byte(i.str))
-			p := parser.New(l.Lex(), "test")
+			errorFmt := serror.ErrorFormatter{
+				Conf:    &core.CONF,
+				Lines:   strings.Split(string(i.str), "\n"),
+				Errors:  make([]serror.Error, 0),
+				Builder: &strings.Builder{},
+			}
+			l := lexer.New([]byte(i.str), &errorFmt)
+			p := parser.New(l.Lex(), "test", &errorFmt)
 			r := Eval(p.Parse())
-			if l.HasError || p.HasError {
+
+			if p.ErrorFormatter.HasErrors() {
 				t.Errorf("lexer or parser error for %q", i.str)
-				return
 			}
 			if len(r) == 0 {
 				t.Errorf("eval result empty for %q", i.str)
@@ -88,9 +97,18 @@ func TestEvalVariables(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i.str, func(t *testing.T) {
-			l := lexer.New([]byte(i.str))
-			p := parser.New(l.Lex(), "test")
+			errorFmt := serror.ErrorFormatter{
+				Conf:    &core.CONF,
+				Lines:   strings.Split(string(i.str), "\n"),
+				Errors:  make([]serror.Error, 0),
+				Builder: &strings.Builder{},
+			}
+			l := lexer.New([]byte(i.str), &errorFmt)
+			p := parser.New(l.Lex(), "test", &errorFmt)
 			r := Eval(p.Parse())
+			if p.ErrorFormatter.HasErrors() {
+				t.Errorf("lexer or parser error for %q", i.str)
+			}
 			if len(r) == 0 {
 				t.Errorf("eval result empty")
 			}
@@ -173,9 +191,18 @@ func TestEvalConditional(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i.str, func(t *testing.T) {
-			l := lexer.New([]byte(i.str))
-			p := parser.New(l.Lex(), "test")
+			errorFmt := serror.ErrorFormatter{
+				Conf:    &core.CONF,
+				Lines:   strings.Split(string(i.str), "\n"),
+				Errors:  make([]serror.Error, 0),
+				Builder: &strings.Builder{},
+			}
+			l := lexer.New([]byte(i.str), &errorFmt)
+			p := parser.New(l.Lex(), "test", &errorFmt)
 			r := Eval(p.Parse())
+			if p.ErrorFormatter.HasErrors() {
+				t.Errorf("lexer or parser error for %q", i.str)
+			}
 			if len(r) == 0 {
 				t.Errorf("eval result empty")
 			}
@@ -206,12 +233,17 @@ func TestEvalArraySpread(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i.str, func(t *testing.T) {
-			l := lexer.New([]byte(i.str))
-			p := parser.New(l.Lex(), "test")
+			errorFmt := serror.ErrorFormatter{
+				Conf:    &core.CONF,
+				Lines:   strings.Split(string(i.str), "\n"),
+				Errors:  make([]serror.Error, 0),
+				Builder: &strings.Builder{},
+			}
+			l := lexer.New([]byte(i.str), &errorFmt)
+			p := parser.New(l.Lex(), "test", &errorFmt)
 			r := Eval(p.Parse())
-			if l.HasError || p.HasError {
+			if p.ErrorFormatter.HasErrors() {
 				t.Errorf("lexer or parser error for %q", i.str)
-				return
 			}
 			if len(r) == 0 {
 				t.Errorf("eval result empty for %q", i.str)
@@ -249,12 +281,17 @@ func TestEvalMerge(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i.str, func(t *testing.T) {
-			l := lexer.New([]byte(i.str))
-			p := parser.New(l.Lex(), "test")
+			errorFmt := serror.ErrorFormatter{
+				Conf:    &core.CONF,
+				Lines:   strings.Split(string(i.str), "\n"),
+				Errors:  make([]serror.Error, 0),
+				Builder: &strings.Builder{},
+			}
+			l := lexer.New([]byte(i.str), &errorFmt)
+			p := parser.New(l.Lex(), "test", &errorFmt)
 			r := Eval(p.Parse())
-			if l.HasError || p.HasError {
+			if p.ErrorFormatter.HasErrors() {
 				t.Errorf("lexer or parser error for %q", i.str)
-				return
 			}
 			if len(r) == 0 {
 				t.Errorf("eval result empty for %q", i.str)
@@ -288,12 +325,17 @@ func TestEvalFunction(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i.str, func(t *testing.T) {
-			l := lexer.New([]byte(i.str))
-			p := parser.New(l.Lex(), "test")
+			errorFmt := serror.ErrorFormatter{
+				Conf:    &core.CONF,
+				Lines:   strings.Split(string(i.str), "\n"),
+				Errors:  make([]serror.Error, 0),
+				Builder: &strings.Builder{},
+			}
+			l := lexer.New([]byte(i.str), &errorFmt)
+			p := parser.New(l.Lex(), "test", &errorFmt)
 			r := Eval(p.Parse())
-			if l.HasError || p.HasError {
+			if p.ErrorFormatter.HasErrors() {
 				t.Errorf("lexer or parser error for %q", i.str)
-				return
 			}
 			if len(r) == 0 {
 				t.Errorf("eval result empty for %q", i.str)
@@ -320,12 +362,17 @@ func TestEvalLoop(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i.str, func(t *testing.T) {
-			l := lexer.New([]byte(i.str))
-			p := parser.New(l.Lex(), "test")
+			errorFmt := serror.ErrorFormatter{
+				Conf:    &core.CONF,
+				Lines:   strings.Split(string(i.str), "\n"),
+				Errors:  make([]serror.Error, 0),
+				Builder: &strings.Builder{},
+			}
+			l := lexer.New([]byte(i.str), &errorFmt)
+			p := parser.New(l.Lex(), "test", &errorFmt)
 			r := Eval(p.Parse())
-			if l.HasError || p.HasError {
+			if p.ErrorFormatter.HasErrors() {
 				t.Errorf("lexer or parser error for %q", i.str)
-				return
 			}
 			if len(r) == 0 {
 				t.Errorf("eval result empty for %q", i.str)

--- a/core/expr/add.go
+++ b/core/expr/add.go
@@ -22,9 +22,9 @@ func (a *Add) Eval() any {
 	res := 0.0
 	for i, c := range a.Children {
 		if i == 0 {
-			res = castPanicIfNotType[float64](c.Eval(), token.ADD)
+			res = castPanicIfNotType[float64](c.Eval(), a.Token)
 		} else {
-			res += castPanicIfNotType[float64](c.Eval(), token.ADD)
+			res += castPanicIfNotType[float64](c.Eval(), a.Token)
 		}
 	}
 	return res

--- a/core/expr/and.go
+++ b/core/expr/and.go
@@ -17,7 +17,7 @@ func (a *And) GetToken() token.Token {
 
 func (a *And) Eval() any {
 	for _, c := range a.Children {
-		v := castPanicIfNotType[bool](c.Eval(), token.AND)
+		v := castPanicIfNotType[bool](c.Eval(), a.Token)
 		if !v {
 			return false
 		}

--- a/core/expr/call.go
+++ b/core/expr/call.go
@@ -1,8 +1,8 @@
 package expr
 
 import (
-	"fmt"
 	"sophia/core/consts"
+	"sophia/core/serror"
 	"sophia/core/token"
 	"strings"
 )
@@ -24,19 +24,22 @@ func (c *Call) Eval() any {
 
 	storedFunc, ok := consts.FUNC_TABLE[c.Token.Raw]
 	if !ok {
-		panic(fmt.Sprintf("function %q not defined", c.Token.Raw))
+		serror.Add(&c.Token, "Undefined function", "Function %q not defined", c.Token.Raw)
+		serror.Panic()
 	}
 
-	def := castPanicIfNotType[*Func](storedFunc, token.IDENT)
-	defParams := castPanicIfNotType[*Params](def.Params, token.IDENT)
+	def := castPanicIfNotType[*Func](storedFunc, c.Token)
+	defParams := castPanicIfNotType[*Params](def.Params, c.Token)
 
 	if len(defParams.Children) != len(c.Params) {
 		paramLen := len(defParams.Children)
 		argLen := len(c.Params)
 		if paramLen < argLen {
-			panic(fmt.Sprintf("too many arguments for %q, wanted %d, got %d", c.Token.Raw, len(defParams.Children), len(c.Params)))
+			serror.Add(&c.Token, "Too many arguments", "Too many arguments for %q, wanted %d, got %d", c.Token.Raw, len(defParams.Children), len(c.Params))
+			serror.Panic()
 		} else if paramLen > argLen {
-			panic(fmt.Sprintf("not enough arguments for %q, wanted %d, got %d", c.Token.Raw, len(defParams.Children), len(c.Params)))
+			serror.Add(&c.Token, "Not enough arguments", "Not enough arguments for %q, wanted %d, got %d", c.Token.Raw, len(defParams.Children), len(c.Params))
+			serror.Panic()
 		}
 	}
 

--- a/core/expr/div.go
+++ b/core/expr/div.go
@@ -22,9 +22,9 @@ func (d *Div) Eval() any {
 	res := 0.0
 	for i, c := range d.Children {
 		if i == 0 {
-			res = castPanicIfNotType[float64](c.Eval(), token.DIV)
+			res = castPanicIfNotType[float64](c.Eval(), d.Token)
 		} else {
-			res /= castPanicIfNotType[float64](c.Eval(), token.DIV)
+			res /= castPanicIfNotType[float64](c.Eval(), d.Token)
 		}
 	}
 	return res

--- a/core/expr/float.go
+++ b/core/expr/float.go
@@ -1,7 +1,7 @@
 package expr
 
 import (
-	"fmt"
+	"sophia/core/serror"
 	"sophia/core/token"
 	"strconv"
 	"strings"
@@ -16,7 +16,6 @@ func (f *Float) GetToken() token.Token {
 }
 
 func (f *Float) Eval() any {
-	// TODO: absolutly move this to the parser
 	before, after, found := strings.Cut(f.Token.Raw, "..")
 	if found {
 		var first float64
@@ -26,17 +25,20 @@ func (f *Float) Eval() any {
 			var err error
 			first, err = strconv.ParseFloat(before, 64)
 			if err != nil {
-				panic(fmt.Sprint("failed to parse float: ", err))
+				serror.Add(&f.Token, "Float parse error", "Failed to parse float %q: %q", f.Token.Raw, err)
+				serror.Panic()
 			}
 		}
 
 		if len(after) == 0 {
-			panic("upper bound of array spread operator required")
+			serror.Add(&f.Token, "Array spread error", "Upper array spread limit required")
+			serror.Panic()
 		}
 
 		last, err := strconv.ParseFloat(after, 64)
 		if err != nil {
-			panic(fmt.Sprint("failed to parse float: ", err))
+			serror.Add(&f.Token, "Float parse error", "Failed to parse float %q: %q", f.Token.Raw, err)
+			serror.Panic()
 		}
 		r := make([]interface{}, 0)
 		for i := first; i < last+1; i++ {
@@ -46,7 +48,8 @@ func (f *Float) Eval() any {
 	}
 	float, err := strconv.ParseFloat(f.Token.Raw, 64)
 	if err != nil {
-		panic(fmt.Sprint("failed to parse float: ", err))
+		serror.Add(&f.Token, "Float parse error", "Failed to parse float %q: %q", f.Token.Raw, err)
+		serror.Panic()
 	}
 	return float
 }

--- a/core/expr/for.go
+++ b/core/expr/for.go
@@ -25,13 +25,13 @@ func (f *For) Eval() any {
 	if len(params) < 1 {
 		panic(fmt.Sprintf("expected at least %d parameters in loop, got %d", 1, len(params)))
 	}
-	element := castPanicIfNotType[*Ident](params[0], token.FOR)
+	element := castPanicIfNotType[*Ident](params[0], params[0].GetToken())
 	oldValue, foundOldValue := consts.SYMBOL_TABLE[element.Name]
 
 	v := f.LoopOver.Eval()
 	switch v.(type) {
 	case []interface{}:
-		loopOver := castPanicIfNotType[[]interface{}](v, token.FOR)
+		loopOver := castPanicIfNotType[[]interface{}](v, f.LoopOver.GetToken())
 
 		for _, el := range loopOver {
 			consts.SYMBOL_TABLE[element.Name] = el

--- a/core/expr/gt.go
+++ b/core/expr/gt.go
@@ -15,6 +15,6 @@ func (g *Gt) GetToken() token.Token {
 }
 
 func (g *Gt) Eval() any {
-	return castPanicIfNotType[float64](g.Children[0].Eval(), token.GT) > castPanicIfNotType[float64](g.Children[1].Eval(), token.GT)
+	return castPanicIfNotType[float64](g.Children[0].Eval(), g.Children[0].GetToken()) > castPanicIfNotType[float64](g.Children[1].Eval(), g.Children[1].GetToken())
 }
 func (n *Gt) CompileJs(b *strings.Builder) {}

--- a/core/expr/ident.go
+++ b/core/expr/ident.go
@@ -1,8 +1,8 @@
 package expr
 
 import (
-	"fmt"
 	"sophia/core/consts"
+	"sophia/core/serror"
 	"sophia/core/token"
 	"strings"
 )
@@ -20,7 +20,8 @@ func (i *Ident) GetToken() token.Token {
 func (i *Ident) Eval() any {
 	val, ok := consts.SYMBOL_TABLE[i.Name]
 	if !ok {
-		panic(fmt.Sprintf("variable '%s' is not defined!", i.Name))
+		serror.Add(&i.Token, "Undefined variable", "Variable %q is not defined.", i.Name)
+		serror.Panic()
 	}
 	return val
 }

--- a/core/expr/if.go
+++ b/core/expr/if.go
@@ -17,7 +17,7 @@ func (i *If) GetToken() token.Token {
 }
 
 func (i *If) Eval() any {
-	cond := castPanicIfNotType[bool](i.Condition.Eval(), token.IF)
+	cond := castPanicIfNotType[bool](i.Condition.Eval(), i.Condition.GetToken())
 	if cond {
 		for _, c := range i.Body {
 			c.Eval()

--- a/core/expr/load.go
+++ b/core/expr/load.go
@@ -7,7 +7,7 @@ import (
 
 type Load struct {
 	Token   token.Token
-	Imports []string
+	Imports []Node
 }
 
 func (l *Load) GetToken() token.Token {

--- a/core/expr/lt.go
+++ b/core/expr/lt.go
@@ -15,6 +15,6 @@ func (l *Lt) GetToken() token.Token {
 }
 
 func (l *Lt) Eval() any {
-	return castPanicIfNotType[float64](l.Children[0].Eval(), token.LT) < castPanicIfNotType[float64](l.Children[1].Eval(), token.LT)
+	return castPanicIfNotType[float64](l.Children[0].Eval(), l.Children[0].GetToken()) < castPanicIfNotType[float64](l.Children[1].Eval(), l.Children[1].GetToken())
 }
 func (n *Lt) CompileJs(b *strings.Builder) {}

--- a/core/expr/mod.go
+++ b/core/expr/mod.go
@@ -23,9 +23,9 @@ func (m *Mod) Eval() any {
 	res := 0
 	for i, c := range m.Children {
 		if i == 0 {
-			res = int(castPanicIfNotType[float64](c.Eval(), token.MOD))
+			res = int(castPanicIfNotType[float64](c.Eval(), c.GetToken()))
 		} else {
-			res = res % int(castPanicIfNotType[float64](c.Eval(), token.MOD))
+			res = res % int(castPanicIfNotType[float64](c.Eval(), c.GetToken()))
 		}
 	}
 	return float64(res)

--- a/core/expr/mul.go
+++ b/core/expr/mul.go
@@ -22,9 +22,9 @@ func (m *Mul) Eval() any {
 	res := 0.0
 	for i, c := range m.Children {
 		if i == 0 {
-			res = castPanicIfNotType[float64](c.Eval(), token.MUL)
+			res = castPanicIfNotType[float64](c.Eval(), c.GetToken())
 		} else {
-			res *= castPanicIfNotType[float64](c.Eval(), token.MUL)
+			res *= castPanicIfNotType[float64](c.Eval(), c.GetToken())
 		}
 	}
 	return res

--- a/core/expr/neg.go
+++ b/core/expr/neg.go
@@ -15,8 +15,7 @@ func (n *Neg) GetToken() token.Token {
 }
 
 func (n *Neg) Eval() any {
-	ev := n.Children.Eval()
-	return !castPanicIfNotType[bool](ev, token.NEG)
+	return !castPanicIfNotType[bool](n.Children.Eval(), n.Children.GetToken())
 }
 func (n *Neg) CompileJs(b *strings.Builder) {
 	b.WriteRune('!')

--- a/core/expr/object.go
+++ b/core/expr/object.go
@@ -22,7 +22,7 @@ func (o *Object) GetToken() token.Token {
 func (o *Object) Eval() any {
 	m := make(map[string]any, len(o.Children))
 	for _, c := range o.Children {
-		key := castPanicIfNotType[*Ident](c.Key, token.LEFT_CURLY)
+		key := castPanicIfNotType[*Ident](c.Key, c.Key.GetToken())
 		m[key.Name] = c.Value.Eval()
 	}
 	return m

--- a/core/expr/or.go
+++ b/core/expr/or.go
@@ -17,7 +17,7 @@ func (o *Or) GetToken() token.Token {
 
 func (o *Or) Eval() any {
 	for _, c := range o.Children {
-		if castPanicIfNotType[bool](c.Eval(), token.OR) {
+		if castPanicIfNotType[bool](c.Eval(), c.GetToken()) {
 			return true
 		}
 	}

--- a/core/expr/sub.go
+++ b/core/expr/sub.go
@@ -22,9 +22,9 @@ func (s *Sub) Eval() any {
 	res := 0.0
 	for i, c := range s.Children {
 		if i == 0 {
-			res = castPanicIfNotType[float64](c.Eval(), token.SUB)
+			res = castPanicIfNotType[float64](c.Eval(), c.GetToken())
 		} else {
-			res -= castPanicIfNotType[float64](c.Eval(), token.SUB)
+			res -= castPanicIfNotType[float64](c.Eval(), c.GetToken())
 		}
 	}
 	return res

--- a/core/expr/util.go
+++ b/core/expr/util.go
@@ -1,17 +1,18 @@
 package expr
 
 import (
-	"fmt"
+	"sophia/core/serror"
 	"sophia/core/token"
 )
 
 // attempts to cast `in` to `T`, returns `in` cast to `T` if successful. If
 // cast fails, panics.
-func castPanicIfNotType[T any](in any, op int) T {
+func castPanicIfNotType[T any](in any, t token.Token) T {
 	val, ok := in.(T)
 	if !ok {
-		panic(fmt.Sprintf("can not use variable of type %T in current operation (%s), expected %T for value %+v", in, token.TOKEN_NAME_MAP[op], val, in))
+		var e T
+		serror.Add(&t, "Type error", "Incompatiable types %T and %T", in, e)
+		serror.Panic()
 	}
 	return val
 }
-

--- a/core/lexer/lexer_test.go
+++ b/core/lexer/lexer_test.go
@@ -5,20 +5,14 @@ import (
 	"sophia/core"
 	"sophia/core/serror"
 	"sophia/core/token"
-	"strings"
 	"testing"
 )
 
 func TestLexerHelloWorld(t *testing.T) {
-	in := []byte(`(put "Hello World!")`)
+	in := `(put "Hello World!")`
 
-	errorFmt := serror.ErrorFormatter{
-		Conf:    &core.CONF,
-		Lines:   strings.Split(string(in), "\n"),
-		Errors:  make([]serror.Error, 0),
-		Builder: &strings.Builder{},
-	}
-	l := New(in, &errorFmt)
+	serror.SetDefault(serror.NewFormatter(&core.CONF, in, "test"))
+	l := New(in)
 	tok := l.Lex()
 	if len(tok) == 0 {
 		t.Error("Lexer found error, token empty")
@@ -50,15 +44,10 @@ func TestLexerFloats(t *testing.T) {
 	}
 	for _, v := range in {
 		t.Run(v, func(t *testing.T) {
-			errorFmt := serror.ErrorFormatter{
-				Conf:    &core.CONF,
-				Lines:   strings.Split(string(v), "\n"),
-				Errors:  make([]serror.Error, 0),
-				Builder: &strings.Builder{},
-			}
-			l := New([]byte(v), &errorFmt)
+			serror.SetDefault(serror.NewFormatter(&core.CONF, v, "test"))
+			l := New(v)
 			o := l.Lex()
-			if errorFmt.HasErrors() {
+			if serror.HasErrors() {
 				t.Fatalf("failed to lex float for input '%s'\n", v)
 			}
 			if o[0].Type != token.FLOAT {
@@ -69,16 +58,11 @@ func TestLexerFloats(t *testing.T) {
 }
 
 func TestLexerIdent(t *testing.T) {
-	in := []byte(`b a abc abcdefghijklmnopqrstuvwxyz`)
-	errorFmt := serror.ErrorFormatter{
-		Conf:    &core.CONF,
-		Lines:   strings.Split(string(in), "\n"),
-		Errors:  make([]serror.Error, 0),
-		Builder: &strings.Builder{},
-	}
-	l := New([]byte(in), &errorFmt)
+	in := `b a abc abcdefghijklmnopqrstuvwxyz`
+	serror.SetDefault(serror.NewFormatter(&core.CONF, in, "test"))
+	l := New(in)
 	to := l.Lex()
-	if errorFmt.HasErrors() {
+	if serror.HasErrors() {
 		t.Error("Lexer found error, token empty")
 	}
 
@@ -95,7 +79,7 @@ func TestLexerIdent(t *testing.T) {
 		"a",
 		"abc",
 		"abcdefghijklmnopqrstuvwxyz",
-		"",
+		" ",
 	}
 
 	for i, tok := range to {
@@ -109,16 +93,11 @@ func TestLexerIdent(t *testing.T) {
 }
 
 func TestLexerOperators(t *testing.T) {
-	in := []byte(`put +-/*% let () if eq or and not ++ fun _ for gt lt match`)
-	errorFmt := serror.ErrorFormatter{
-		Conf:    &core.CONF,
-		Lines:   strings.Split(string(in), "\n"),
-		Errors:  make([]serror.Error, 0),
-		Builder: &strings.Builder{},
-	}
-	l := New([]byte(in), &errorFmt)
+	in := `put +-/*% let () if eq or and not ++ fun _ for gt lt match`
+	serror.SetDefault(serror.NewFormatter(&core.CONF, in, "test"))
+	l := New(in)
 	to := l.Lex()
-	if errorFmt.HasErrors() {
+	if serror.HasErrors() {
 		t.Error("Lexer found error, token empty")
 	}
 
@@ -155,16 +134,11 @@ func TestLexerOperators(t *testing.T) {
 }
 
 func TestLexerArithmetic(t *testing.T) {
-	in := []byte(`(+ 1 (* 1 (/ 1 (% 1))))`)
-	errorFmt := serror.ErrorFormatter{
-		Conf:    &core.CONF,
-		Lines:   strings.Split(string(in), "\n"),
-		Errors:  make([]serror.Error, 0),
-		Builder: &strings.Builder{},
-	}
-	l := New([]byte(in), &errorFmt)
+	in := `(+ 1 (* 1 (/ 1 (% 1))))`
+	serror.SetDefault(serror.NewFormatter(&core.CONF, in, "test"))
+	l := New(in)
 	to := l.Lex()
-	if errorFmt.HasErrors() {
+	if serror.HasErrors() {
 		t.Error("Lexer found error, token empty")
 	}
 
@@ -203,18 +177,13 @@ func TestLexerIgnoreCharsAndComments(t *testing.T) {
 	}
 	for _, v := range in {
 		t.Run(v, func(t *testing.T) {
-			errorFmt := serror.ErrorFormatter{
-				Conf:    &core.CONF,
-				Lines:   strings.Split(string(v), "\n"),
-				Errors:  make([]serror.Error, 0),
-				Builder: &strings.Builder{},
-			}
-			l := New([]byte(v), &errorFmt)
+			serror.SetDefault(serror.NewFormatter(&core.CONF, v, "test"))
+			l := New(v)
 			toks := []token.Token{}
 			if l != nil {
 				toks = l.Lex()
 			}
-			if errorFmt.HasErrors() {
+			if serror.HasErrors() {
 				t.Error("Lexer should have not found errors")
 			}
 			if len(toks) != 1 {
@@ -227,21 +196,15 @@ func TestLexerIgnoreCharsAndComments(t *testing.T) {
 
 func TestLexerErrorsOnUnknownTokenAndIntegers(t *testing.T) {
 	in := []string{
-		"ß",
 		`;;comment
 ?[putc "test"]`,
 	}
 	for _, v := range in {
 		t.Run(v, func(t *testing.T) {
-			errorFmt := serror.ErrorFormatter{
-				Conf:    &core.CONF,
-				Lines:   strings.Split(string(v), "\n"),
-				Errors:  make([]serror.Error, 0),
-				Builder: &strings.Builder{},
-			}
-			l := New([]byte(v), &errorFmt)
+			serror.SetDefault(serror.NewFormatter(&core.CONF, v, "test"))
+			l := New(v)
 			l.Lex()
-			if !errorFmt.HasErrors() {
+			if !serror.HasErrors() {
 				t.Error("Lexer should have found errors")
 			}
 		})
@@ -249,16 +212,11 @@ func TestLexerErrorsOnUnknownTokenAndIntegers(t *testing.T) {
 }
 
 func TestLexerBooleans(t *testing.T) {
-	in := []byte(`true false`)
-	errorFmt := serror.ErrorFormatter{
-		Conf:    &core.CONF,
-		Lines:   strings.Split(string(in), "\n"),
-		Errors:  make([]serror.Error, 0),
-		Builder: &strings.Builder{},
-	}
-	l := New([]byte(in), &errorFmt)
+	in := "true false"
+	serror.SetDefault(serror.NewFormatter(&core.CONF, in, "test"))
+	l := New(in)
 	tok := l.Lex()
-	if errorFmt.HasErrors() {
+	if serror.HasErrors() {
 		t.Error("Lexer found error, token empty")
 	}
 
@@ -271,7 +229,7 @@ func TestLexerBooleans(t *testing.T) {
 	expectedRaw := []string{
 		"true",
 		"false",
-		"",
+		" ",
 	}
 
 	for i, toke := range tok {

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -12,22 +12,20 @@ import (
 )
 
 type Parser struct {
-	token          []token.Token
-	filename       string
-	pos            int
-	ErrorFormatter *serror.ErrorFormatter
+	token    []token.Token
+	filename string
+	pos      int
 }
 
-func New(token []token.Token, filename string, errorFormatter *serror.ErrorFormatter) *Parser {
-	if len(token) == 0 {
-		errorFormatter.Add(nil, "Unexpected end of input", "Source possibly empty")
+func New(tokens []token.Token, filename string) *Parser {
+	if len(tokens) == 0 {
+		serror.Add(&token.Token{LinePos: 0, Raw: " "}, "Unexpected end of input", "Source possibly empty")
 		return &Parser{}
 	}
 	return &Parser{
-		token:          token,
-		pos:            0,
-		filename:       filename,
-		ErrorFormatter: errorFormatter,
+		token:    tokens,
+		pos:      0,
+		filename: filename,
 	}
 }
 
@@ -41,6 +39,9 @@ func (p *Parser) Parse() []expr.Node {
 			}
 			continue
 		}
+		if stmt == nil {
+			return res
+		}
 		res = append(res, stmt)
 	}
 	return res
@@ -49,24 +50,24 @@ func (p *Parser) Parse() []expr.Node {
 func (p *Parser) loadNewSource(node *expr.Load) []expr.Node {
 	res := make([]expr.Node, 0)
 	for i := 0; i < len(node.Imports); i++ {
-		name := node.Imports[i]
-		file, err := os.Open(name)
+		name := node.Imports[i].GetToken()
+		file, err := os.Open(name.Raw)
 		if err != nil {
-			log.Printf("err: %s", err)
-			return nil
+			serror.Add(&name, "Failed to source import", "Couldn't open %q: %q.", name.Raw, err)
+			continue
 		}
 		content, err := io.ReadAll(file)
 		if err != nil {
-			log.Printf("err: failed to read %s", err)
-			return nil
+			serror.Add(&name, "Failed to read import", "Couldn't read %q: %q.", name.Raw, err)
+			continue
 		}
-		lexer := lexer.New(content, p.ErrorFormatter)
+		lexer := lexer.New(string(content))
 		token := lexer.Lex()
-		if name == p.filename {
-			log.Printf("detected recursion in file imports, got %q while already parsing %q", name, p.filename)
-			return nil
+		if name.Raw == p.filename {
+			serror.Add(&name, "Detected recursion in file imports", "Got %q while already parsing %q.", name.Raw, p.filename)
+			continue
 		}
-		parser := New(token, name, p.ErrorFormatter)
+		parser := New(token, name.Raw)
 		res = append(res, parser.Parse()...)
 	}
 	return res
@@ -87,7 +88,11 @@ func (p *Parser) parseStatment() expr.Node {
 		if p.peekIs(token.EOF) || p.peekIs(token.RIGHT_BRACE) {
 			break
 		} else if p.peekIs(token.LEFT_BRACE) {
-			childs = append(childs, p.parseStatment())
+			nStmt := p.parseStatment()
+			if nStmt == nil {
+				return nil
+			}
+			childs = append(childs, nStmt)
 			continue
 		} else {
 			child = p.parseArguments()
@@ -108,36 +113,35 @@ func (p *Parser) parseStatment() expr.Node {
 		}
 	case token.LOAD:
 		if len(childs) == 0 {
-			log.Printf("err: expected at least one argument for loading sources, got %d", len(childs))
+			serror.Add(&op, "Not enough arguments", "Expected at least one argument for loading files, got %d.", len(childs))
 			return nil
 		}
-		imports := make([]string, len(childs))
-		for i, c := range childs {
+		for _, c := range childs {
 			if c.GetToken().Type != token.STRING {
-				log.Printf("err: expected strings as load arguments, got %q", token.TOKEN_NAME_MAP[c.GetToken().Type])
+				t := c.GetToken()
+				serror.Add(&t, "Type error", "Expected an argument of type string for loading files, got %q.", token.TOKEN_NAME_MAP[t.Type])
 				return nil
 			}
-			imports[i] = c.GetToken().Raw
 		}
 		stmt = &expr.Load{
 			Token:   op,
-			Imports: imports,
+			Imports: childs[0:],
 		}
 	case token.FOR:
 		if len(childs) < 2 {
-			log.Printf("err: expected two argument for loop definition, got %d", len(childs))
+			serror.Add(&op, "Not enough arguments", "Expected two argument for loop definition, got %d.", len(childs))
 			return nil
 		}
 		params := childs[0]
+		t := params.GetToken()
 		if params.GetToken().Type != token.PARAM {
-			log.Printf("err: expected the first argument for loop definition to be of type PARAM, got %q", token.TOKEN_NAME_MAP[childs[0].GetToken().Type])
+			serror.Add(&t, "Type error", "Expected the first argument for loop definition to be of type PARAM, got %q.", token.TOKEN_NAME_MAP[childs[0].GetToken().Type])
 			return nil
 		}
 		if len(params.(*expr.Params).Children) != 1 {
-			log.Printf("err: expected one parameter for loop definition, got %d", len(params.(*expr.Params).Children))
+			serror.Add(&t, "Not enough parameters", "Expected one parameter for loop parameter definition, got %d.", len(params.(*expr.Params).Children))
 			return nil
 		}
-		// TODO: check if first is of type params
 		stmt = &expr.For{
 			Token:    op,
 			Params:   params,
@@ -151,7 +155,7 @@ func (p *Parser) parseStatment() expr.Node {
 		}
 	case token.LT:
 		if len(childs) != 2 {
-			log.Printf("err: expected exactly two statements for less than comparison, got %d", len(childs))
+			serror.Add(&op, "Incorrect parameter amount", "Expected exactly two statements for less than comparison, got %d.", len(childs))
 			return nil
 		}
 		stmt = &expr.Lt{
@@ -160,7 +164,7 @@ func (p *Parser) parseStatment() expr.Node {
 		}
 	case token.GT:
 		if len(childs) != 2 {
-			log.Printf("err: expected exactly two statements for greater than comparison, got %d", len(childs))
+			serror.Add(&op, "Incorrect parameter amount", "Expected exactly two statements for greater than comparison, got %d.", len(childs))
 			return nil
 		}
 		stmt = &expr.Gt{
@@ -169,9 +173,9 @@ func (p *Parser) parseStatment() expr.Node {
 		}
 	case token.PARAM:
 		for _, c := range childs {
-			t := c.GetToken().Type
-			if t != token.IDENT {
-				log.Printf("err: expected identifier for parameter definition, got %q", token.TOKEN_NAME_MAP[t])
+			t := c.GetToken()
+			if t.Type != token.IDENT {
+				serror.Add(&t, "Type error", "Expected identifier for parameter definition, got %q.", token.TOKEN_NAME_MAP[t.Type])
 				return nil
 			}
 		}
@@ -181,15 +185,17 @@ func (p *Parser) parseStatment() expr.Node {
 		}
 	case token.FUNC:
 		if len(childs) < 2 {
-			log.Printf("err: expected at least two argument for function definition, got %d", len(childs))
+			serror.Add(&op, "Not enough parameters", "Expected 2 parameters, one for function name and one for parameters, got %d.", len(childs))
 			return nil
 		}
-		if childs[0].GetToken().Type != token.IDENT {
-			log.Printf("err: expected the first argument for function definition to be of type IDENT, got %q", token.TOKEN_NAME_MAP[childs[0].GetToken().Type])
+		t := childs[0].GetToken()
+		if t.Type != token.IDENT {
+			serror.Add(&t, "Type error", "Expected the first argument for function definition to be of type IDENT, got %q.", token.TOKEN_NAME_MAP[t.Type])
 			return nil
 		}
+		t = childs[1].GetToken()
 		if childs[1].GetToken().Type != token.PARAM {
-			log.Printf("err: expected the second argument for function definition to be of type PARAM, got %q", token.TOKEN_NAME_MAP[childs[0].GetToken().Type])
+			serror.Add(&t, "Type error", "Expected the second argument for function definition to be of type PARAM, got %q.", token.TOKEN_NAME_MAP[t.Type])
 			return nil
 		}
 		stmt = &expr.Func{
@@ -200,7 +206,7 @@ func (p *Parser) parseStatment() expr.Node {
 		}
 	case token.IF:
 		if len(childs) == 0 {
-			log.Printf("err: expected at least two argument for condition, got %d", len(childs))
+			log.Printf("err: expected at least two argument for condition, got %d.", len(childs))
 			return nil
 		}
 		cond := childs[0]
@@ -211,7 +217,7 @@ func (p *Parser) parseStatment() expr.Node {
 		}
 	case token.LET:
 		if len(childs) == 0 {
-			log.Printf("err: expected at least one argument for variable declaration, got %d", len(childs))
+			serror.Add(&op, "Not enough arguments", "Expected at least one argument for variable declaration, got %d.", len(childs))
 			return nil
 		}
 		ident := childs[0]
@@ -226,13 +232,17 @@ func (p *Parser) parseStatment() expr.Node {
 			Children: childs,
 		}
 	case token.EQUAL:
+		if len(childs) != 2 {
+			serror.Add(&op, "Incorrect parameter amount", "Expected exactly two statements for equality check, got %d.", len(childs))
+			return nil
+		}
 		stmt = &expr.Equal{
 			Token:    op,
 			Children: childs,
 		}
 	case token.NEG:
 		if len(childs) != 1 {
-			log.Printf("err: expected exactly one argument for negation, got %d", len(childs))
+			serror.Add(&op, "Incorrect parameter amount", "Expected exactly one argument for negation, got %d.", len(childs))
 			return nil
 		}
 		stmt = &expr.Neg{
@@ -336,7 +346,7 @@ func (p *Parser) parseIndex() expr.Node {
 	p.advance()
 	o.Index = p.parseArguments()
 	p.advance()
-	p.peekError(token.RIGHT_BRACKET, "missing object end")
+	p.peekError(token.RIGHT_BRACKET, "missing index end")
 	return &o
 }
 
@@ -352,7 +362,10 @@ func (p *Parser) parseObject() expr.Node {
 			Key: p.parseArguments(),
 		}
 		p.advance()
-		p.peekError(token.COLON, "missing object key value divider")
+		if p.peek().Type != token.COLON {
+			p.peekError(token.COLON, "missing object key value divider")
+			return nil
+		}
 		p.advance()
 		op.Value = p.parseArguments()
 		p.advance()
@@ -410,12 +423,16 @@ func (p *Parser) peekErrorMany(error string, tokenType ...int) {
 			o[i] = token.TOKEN_NAME_MAP[w]
 		}
 		wanted := strings.Join(o, ",")
-		log.Printf("err: %s - Expected any of: '%s', got '%s' [l: %d:%d]", error, wanted, token.TOKEN_NAME_MAP[p.peek().Type], p.peek().Line, p.peek().Pos)
+		t := p.peek()
+		serror.Add(&t, "Unexpected Token", "%s: Expected any of '%s' got '%s'.", error, wanted, token.TOKEN_NAME_MAP[t.Type])
 	}
 }
 
-func (p *Parser) peekError(tokenType int, error string) {
+func (p *Parser) peekError(tokenType int, error string) (r bool) {
 	if !p.peekIs(tokenType) {
-		log.Printf("err: %s - Expected Token '%s' got '%s' [l: %d:%d]", error, token.TOKEN_NAME_MAP[tokenType], token.TOKEN_NAME_MAP[p.peek().Type], p.peek().Line, p.peek().Pos)
+		t := p.peek()
+		serror.Add(&t, "Unexpected Token", "%s: Expected Token '%s' got '%s'.", error, token.TOKEN_NAME_MAP[tokenType], token.TOKEN_NAME_MAP[t.Type])
+		return true
 	}
+	return false
 }

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -6,23 +6,18 @@ import (
 	"sophia/core"
 	"sophia/core/lexer"
 	"sophia/core/serror"
-	"strings"
 	"testing"
 )
 
 func TestParserHelloWorld(t *testing.T) {
-	in := []byte(`(put "Hello World!")`)
-	errorFmt := serror.ErrorFormatter{
-		Conf:    &core.CONF,
-		Lines:   strings.Split(string(in), "\n"),
-		Errors:  make([]serror.Error, 0),
-		Builder: &strings.Builder{},
-	}
-	l := lexer.New([]byte(in), &errorFmt)
+	in := `(put "Hello World!")`
+
+	serror.SetDefault(serror.NewFormatter(&core.CONF, in, "test"))
+	l := lexer.New(in)
 	token := l.Lex()
 
-	New(token, "test", &errorFmt)
-	if errorFmt.HasErrors() {
+	New(token, "test")
+	if serror.HasErrors() {
 		t.Error("error while parsing hello world")
 	}
 }
@@ -44,16 +39,11 @@ func TestParserErrors(t *testing.T) {
 	}
 	for _, s := range in {
 		t.Run(s, func(t *testing.T) {
-			errorFmt := serror.ErrorFormatter{
-				Conf:    &core.CONF,
-				Lines:   strings.Split(string(s), "\n"),
-				Errors:  make([]serror.Error, 0),
-				Builder: &strings.Builder{},
-			}
-			l := lexer.New([]byte(s), &errorFmt)
-			p := New(l.Lex(), "test", &errorFmt)
+			serror.SetDefault(serror.NewFormatter(&core.CONF, s, "test"))
+			l := lexer.New(s)
+			p := New(l.Lex(), "test")
 			p.Parse()
-			if errorFmt.HasErrors() {
+			if !serror.HasErrors() {
 				t.Errorf("parsing should fail for %q, it did not", s)
 			}
 		})

--- a/core/run/repl.go
+++ b/core/run/repl.go
@@ -10,7 +10,8 @@ import (
 )
 
 func repl(run func(input []byte, filename string) ([]string, error)) {
-	fmt.Println(`Welcome to the Sophia repl - press <CTRL-D> or <CTRL-C> to quit...`)
+	log.SetFlags(0)
+	fmt.Println(`Welcome to the Sophia programming language repl - press <CTRL-D> or <CTRL-C> to quit...`)
 
 	rl, err := readline.NewEx(&readline.Config{
 		Prompt: "ß :: ",

--- a/core/run/repl.go
+++ b/core/run/repl.go
@@ -6,15 +6,14 @@ import (
 	"log"
 	"sophia/core"
 	"sophia/core/consts"
-	"strings"
 )
 
-func repl(run func(input []byte, filename string) ([]string, error)) {
+func repl(run func(input string, filename string) ([]string, error)) {
 	log.SetFlags(0)
 	fmt.Println(`Welcome to the Sophia programming language repl - press <CTRL-D> or <CTRL-C> to quit...`)
 
 	rl, err := readline.NewEx(&readline.Config{
-		Prompt: "ß :: ",
+		Prompt: "sophia> ",
 	})
 	if err != nil {
 		panic(err)
@@ -26,7 +25,6 @@ func repl(run func(input []byte, filename string) ([]string, error)) {
 		if err != nil {
 			break
 		}
-		line = strings.TrimSpace(line)
 		if len(line) == 0 {
 			continue
 		}
@@ -42,7 +40,7 @@ func repl(run func(input []byte, filename string) ([]string, error)) {
 				log.Printf("toggled debug logging to='%t'", core.CONF.Debug)
 			}
 		} else {
-			val, error := run([]byte(line), "repl")
+			val, error := run(line, "repl")
 			if error != nil {
 				log.Println(error)
 			} else {

--- a/core/run/start.go
+++ b/core/run/start.go
@@ -15,10 +15,12 @@ func Start() {
 	execute := flag.String("exp", "", "specifiy expression to execute")
 	target := flag.String("target", "", "specifiy target to compile sophia to")
 	dbg := flag.Bool("dbg", false, "enable debug logs")
+	allErrors := flag.Bool("all-errors", false, "display all found errors")
 	flag.Parse()
 	core.CONF = core.Config{
-		Debug:  *dbg,
-		Target: *target,
+		Debug:     *dbg,
+		Target:    *target,
+		AllErrors: *allErrors,
 	}
 
 	stdinInf, err := os.Stdin.Stat()
@@ -29,13 +31,13 @@ func Start() {
 		if err != nil {
 			log.Fatalln("failed to read from stdin", err)
 		}
-		_, err = run(out, "stdin")
+		_, err = run(string(out), "stdin")
 		if err != nil {
 			log.Fatalln(err)
 		}
 	} else if len(*execute) != 0 {
 		debug.Log("got -exp flag, running...")
-		_, err := run([]byte(*execute), "cli")
+		_, err := run(*execute, "cli")
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -46,17 +48,16 @@ func Start() {
 		if err != nil {
 			log.Fatalf("Failed to open file: %s\n", err)
 		}
-		_, err = run(f, file)
+		_, err = run(string(f), file)
 		if err != nil {
-			log.Println(err)
-			log.Fatalf("error in source file '%s' detected, stopping...", file)
+			log.Fatalln("\n" + err.Error())
 		}
 	} else {
 		if len(core.CONF.Target) > 0 {
 			log.Fatalf("got compile target %q, but no file or expression to compile, exiting...", core.CONF.Target)
 		}
 		fmt.Print(core.ASCII_ART, "\n")
-		debug.Log("go nothing, starting repl...")
+		debug.Log("got nothing, starting repl...")
 		repl(run)
 	}
 }

--- a/core/run/start.go
+++ b/core/run/start.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Start() {
-	log.SetFlags(log.Ltime | log.Lmicroseconds)
+	log.SetFlags(0)
 	execute := flag.String("exp", "", "specifiy expression to execute")
 	target := flag.String("target", "", "specifiy target to compile sophia to")
 	dbg := flag.Bool("dbg", false, "enable debug logs")

--- a/core/serror/default.go
+++ b/core/serror/default.go
@@ -1,0 +1,43 @@
+package serror
+
+import (
+	"sophia/core"
+	"sophia/core/token"
+	"strings"
+)
+
+var defaultFormatter *ErrorFormatter
+
+func Add(t *token.Token, title string, info string, additional ...any) {
+	defaultFormatter.Add(t, title, info, additional...)
+}
+
+func Display() {
+	defaultFormatter.Display()
+}
+
+func HasErrors() bool {
+	return defaultFormatter.HasErrors()
+}
+
+func SetDefault(e *ErrorFormatter) {
+	defaultFormatter = e
+}
+
+func Default() *ErrorFormatter {
+	return defaultFormatter
+}
+
+func Panic() {
+	panic("Runtime error")
+}
+
+func NewFormatter(config *core.Config, input string, filename string) *ErrorFormatter {
+	return &ErrorFormatter{
+		conf:    config,
+		lines:   strings.Split(input, "\n"),
+		file:    filename,
+		builder: &strings.Builder{},
+		errors:  make([]Error, 0),
+	}
+}

--- a/core/serror/error.go
+++ b/core/serror/error.go
@@ -1,0 +1,61 @@
+// Provides functionality for bubbling internal errors up to the user in a
+// pretty and concise way
+package serror
+
+import (
+	"fmt"
+	"log"
+	"sophia/core"
+	"sophia/core/token"
+	"strings"
+)
+
+const MAX_ERRORS = 5
+
+type ErrorFormatter struct {
+	Conf    *core.Config
+	Lines   []string
+	Errors  []Error
+	Builder *strings.Builder
+}
+
+func (e *ErrorFormatter) HasErrors() bool {
+	return len(e.Errors) > 0
+}
+
+func (e *ErrorFormatter) Add(t *token.Token, title string, info string, additional ...any) {
+	e.Errors = append(e.Errors, Error{t, title, fmt.Sprintf(info, additional...)})
+}
+
+func (e *ErrorFormatter) Display() {
+	for i, err := range e.Errors {
+		if i < MAX_ERRORS && !e.Conf.AllErrors {
+			log.Println(err.prettyPrint(e.Builder))
+		} else {
+			log.Printf("More than %d errors, skipping the remaining %d, rerun with '-all-errors' to view all", MAX_ERRORS, len(e.Errors)-MAX_ERRORS)
+			break
+		}
+	}
+}
+
+type Error struct {
+	Token *token.Token
+	Title string // smth like Unknown token
+	Info  string // in depth information: expected 'x' got 'y'
+}
+
+func (e *Error) prettyPrint(builder *strings.Builder) string {
+	str := builder.String()
+	builder.Reset()
+	return str
+}
+
+// writes rune 'r' 'n' times into 'builder'
+func runeRepeat(builder *strings.Builder, r rune, n int) {
+	if n <= 0 {
+		return
+	}
+	for i := 0; i < n; i++ {
+		builder.WriteRune(r)
+	}
+}

--- a/core/token/token.go
+++ b/core/token/token.go
@@ -1,8 +1,9 @@
 package token
 
 type Token struct {
-	Pos  int
-	Line int
-	Type int
-	Raw  string
+	Pos     int
+	Line    int
+	LinePos int
+	Type    int
+	Raw     string
 }

--- a/examples/functions.phia
+++ b/examples/functions.phia
@@ -6,3 +6,4 @@
 
 (let r (square 12))
 (put '12^2 -> {r}')
+

--- a/examples/variables.phia
+++ b/examples/variables.phia
@@ -12,7 +12,7 @@
 (let person { 
     name: "anon" 
     age: 25 
-    })
+})
 (let [person.name] "anon2")
 (let [person.test] "test")
 (let newAge 
@@ -24,7 +24,7 @@
     data: {
         test: "test"
     }
-    })
+})
 
 (let pData [person.data])
 (put [pData.data])


### PR DESCRIPTION
This pr intends to introduce error display as previously implemented in the lexer for the whole application. The goal is to display the line the error occurred on and the previous 2 lines. Furthermore, a title for each error and an optional description / in depth information or hints for fixing the error are to be implemented. Errors should be consistently displayed with line numbers, title, highlighting the offending code in the displayed snippet and description.

Examples:

Unknown character without a description:
![image](https://github.com/xNaCly/Sophia/assets/47723417/6b0a4679-daa3-4752-a9b3-837d4eecd346)


Unterminated String:
![image](https://github.com/xNaCly/Sophia/assets/47723417/598f9ded-0c28-436c-9266-f42ce6a8eca0)
